### PR TITLE
add support for hpc7g family of images

### DIFF
--- a/aws-efa-k8s-device-plugin/values.yaml
+++ b/aws-efa-k8s-device-plugin/values.yaml
@@ -42,6 +42,10 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - g5.24xlarge
     - g5.48xlarge
     - g5.8xlarge
+    - hpc6a.48xlarge
+    - hpc7g.16xlarge
+    - hpc7g.8xlarge
+    - hpc7g.4xlarge
     - i3en.12xlarge
     - i3en.24xlarge
     - i3en.metal


### PR DESCRIPTION
This is a follow up to https://github.com/weaveworks/eksctl/pull/6743 to update the config here to allow support for the new hpc7g family of ARM images.

Note that this should not be merged yet, as the image family does not appear to work with EFA. I cannot see the source code of the build, but I can show you a working vs. not working example. Here is the result of using [this branch]() with the `im4gn.16xlarge` instance (also ARM) and it works:

```console
2023/07/01 20:11:59 Fetching EFA devices.
2023/07/01 20:11:59 device: rdmap0s6,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap0s6
2023/07/01 20:11:59 EFA Device list: [{rdmap0s6 uverbs0 /sys/class/infiniband_verbs/uverbs0 /sys/class/infiniband/rdmap0s6}]
2023/07/01 20:11:59 Starting FS watcher.
2023/07/01 20:11:59 Starting OS watcher.
2023/07/01 20:11:59 device: rdmap0s6,uverbs0,/sys/class/infiniband_verbs/uverbs0,/sys/class/infiniband/rdmap0s6
2023/07/01 20:11:59 Starting to serve on /var/lib/kubelet/device-plugins/aws-efa-device-plugin.sock
2023/07/01 20:11:59 Registered device plugin with Kubelet
```

And for comparison, using the same logic / setup (aside from the instance type / resources) we cannot find an EFA plugin for `hpc7g.16xlarge`

```console
2023/07/01 19:35:42 Fetching EFA devices.
2023/07/01 19:35:42 No devices found.
```

And the containers go into CrashLoopBackoff. I'm including this here in case anyone that reads this repository has access to the private repository where the plugin code is hosted. We have a good debugging setup from the above - two arm images, where it works for one but not for the other! So my suggestion would be to find the plugin code that asserts that the devices exist, and assess the logic in the context of the different ARM images. Likely whatever detail is different is leading to this result.

Thanks for your help!