### PR TITLE
Cleaned up helm chart and change EFA plugin version to latest

### DIFF
--- a/aws-efa-k8s-device-plugin/Chart.yaml
+++ b/aws-efa-k8s-device-plugin/Chart.yaml
@@ -3,4 +3,4 @@ name: aws-efa-k8s-device-plugin
 description: A Helm chart for EFA device plugin.
 type: application
 version: 0.1.0
-appVersion: "v0.3.3"
+appVersion: "v0.4.2"

--- a/aws-efa-k8s-device-plugin/templates/daemonset.yaml
+++ b/aws-efa-k8s-device-plugin/templates/daemonset.yaml
@@ -12,12 +12,11 @@ spec:
     type: RollingUpdate
   template:
     metadata:
-      # This annotation is deprecated. Kept here for backward compatibility
-      # See https://kubernetes.io/docs/tasks/administer-cluster/guaranteed-scheduling-critical-addon-pods/
+      {{- if .Values.additionalPodAnnotations }}
       annotations:
-        scheduler.alpha.kubernetes.io/critical-pod: ""
         {{- with .Values.additionalPodAnnotations }}
           {{- toYaml . | nindent 8 }}
+        {{- end }}
         {{- end }}
       labels:
         name: {{ include "aws-efa-k8s-device-plugin.fullname" . }}
@@ -58,7 +57,6 @@ spec:
       hostNetwork: true
       containers:
         - image: {{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
-          imagePullPolicy: Always
           name: aws-efa-k8s-device-plugin
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12}}

--- a/aws-efa-k8s-device-plugin/values.yaml
+++ b/aws-efa-k8s-device-plugin/values.yaml
@@ -1,34 +1,19 @@
 image:
   repository: 602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efa-k8s-device-plugin
-  pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.3.3"
+  tag: "v0.4.2"
 securityContext:
   allowPrivilegeEscalation: false
   capabilities:
     drop: ["ALL"]
+  runAsNonRoot: false
 supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types
   keys:
-    - "beta.kubernetes.io/instance-type"
     - "node.kubernetes.io/instance-type"
   values:
-    - m5dn.24xlarge
-    - m5dn.metal
-    - m5n.24xlarge
-    - m5n.metal
-    - m5zn.12xlarge
-    - m5zn.metal
-    - m6a.32xlarge
-    - m6a.48xlarge
-    - m6a.metal
-    - m6i.32xlarge
-    - m6i.metal
-    - m6id.32xlarge
-    - m6id.metal
     - c5n.18xlarge
     - c5n.9xlarge
     - c5n.metal
-    - c6a.32xlarge
     - c6a.48xlarge
     - c6a.metal
     - c6gn.16xlarge
@@ -36,39 +21,94 @@ supportedInstanceLabels: # EFA supported instances: https://docs.aws.amazon.com/
     - c6i.metal
     - c6id.32xlarge
     - c6id.metal
-    - hpc6a.48xlarge
+    - c6in.32xlarge
+    - c6in.metal
+    - c7a.48xlarge
+    - c7a.metal-48xl
+    - c7g.16xlarge
+    - c7g.metal
+    - c7gd.16xlarge
+    - c7gn.16xlarge
+    - c7i.48xlarge
+    - c7i.metal-48xl
+    - dl1.24xlarge
+    - dl2q.24xlarge
+    - g4dn.12xlarge
+    - g4dn.16xlarge
+    - g4dn.8xlarge
+    - g4dn.metal
+    - g5.12xlarge
+    - g5.16xlarge
+    - g5.24xlarge
+    - g5.48xlarge
+    - g5.8xlarge
+    - i3en.12xlarge
+    - i3en.24xlarge
+    - i3en.metal
+    - i4g.16xlarge
+    - i4i.32xlarge
+    - i4i.metal
+    - im4gn.16xlarge
+    - inf1.24xlarge
+    - m5dn.24xlarge
+    - m5dn.metal
+    - m5n.24xlarge
+    - m5n.metal
+    - m5zn.12xlarge
+    - m5zn.metal
+    - m6a.48xlarge
+    - m6a.metal
+    - m6i.32xlarge
+    - m6i.metal
+    - m6id.32xlarge
+    - m6id.metal
+    - m6idn.32xlarge
+    - m6idn.metal
+    - m6in.32xlarge
+    - m6in.metal
+    - m7a.48xlarge
+    - m7a.metal-48xl
+    - m7g.16xlarge
+    - m7g.metal
+    - m7gd.16xlarge
+    - m7i.48xlarge
+    - m7i.metal-48xl
+    - p3dn.24xlarge
+    - p4d.24xlarge
+    - p5.48xlarge
     - r5dn.24xlarge
     - r5dn.metal
     - r5n.24xlarge
     - r5n.metal
+    - r6a.48xlarge
+    - r6a.metal
     - r6i.32xlarge
     - r6i.metal
     - r6id.32xlarge
     - r6id.metal
-    - x2d.32xlarge
-    - x2d.metal
-    - x2ed.32xlarge
-    - x2ed.metal
-    - x2iezn.12xlarge
-    - x2iezn.metal
+    - r6idn.32xlarge
+    - r6idn.metal
+    - r6in.32xlarge
+    - r6in.metal
+    - r7a.48xlarge
+    - r7a.metal-48xl
+    - r7g.16xlarge
+    - r7g.metal
+    - r7gd.16xlarge
+    - r7i.48xlarge
+    - r7i.metal-48xl
+    - r7iz.32xlarge
+    - r7iz.metal-32xl
+    - trn1.32xlarge
+    - trn1n.32xlarge
+    - vt1.24xlarge
     - x2idn.32xlarge
+    - x2idn.metal
     - x2iedn.32xlarge
-    - i3en.24xlarge
-    - i3en.12xlarge
-    - i3en.metal
-    - i4i.32xlarge
-    - i4i.metal
-    - im4gn.16xlarge
-    - dl1.24xlarge
-    - g4dn.8xlarge
-    - g4dn.12xlarge
-    - g4dn.metal
-    - g5.48xlarge
-    - inf1.24xlarge
-    - p3dn.24xlarge
-    - p4d.24xlarge
-    - p4de.24xlarge
-resources: {}
+    - x2iedn.metal
+    - x2iezn.12xlarge
+    - x2iezn.metal 
+resources:
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -76,9 +116,9 @@ resources: {}
   # limits:
   #   cpu: 100m
   #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+   requests:
+     cpu:     10m
+     memory:  20Mi
 nodeSelector: {}
 #  efa: present
 tolerations: []


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
* Updated EFA-compatible instances
* Removed old annotations
* Remove `imagePullPolicy`
* Added CPU and Memory requests


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
